### PR TITLE
Simpler build, using pkgdepends directly

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -67,9 +67,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-          pak::local_install_dev_deps()
-          pak::pkg_install("rcmdcheck")
+          install.packages(c("remotes"))
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-          pak::local_install_dev_deps()
-          pak::pkg_install("covr")
+          install.packages(c("remotes"))
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
       - name: Test coverage

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           install.packages(c("remotes"))
           remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
+          remotes::install_cran("covr")
         shell: Rscript {0}
 
       - name: Test coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+.DS_Store
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,8 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Language: en-GB
+URL: https://github.com/mrc-ide/pkgbuilder
+BugReports: https://github.com/mrc-ide/pkgbuilder/issues
 Imports:
     callr,
     ids,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
     gert,
     jsonlite,
     liteq,
-    pak (>= 0.1.2.9001),
     pkgapi,
     pkgbuild,
     pkgdepends,
@@ -31,4 +30,3 @@ Remotes:
     r-lib/pkgdepends,
     ropensci/jsonvalidate,
     reside-ic/pkgapi
-Additional_repositories: https://r-lib.github.io/p/pak/dev/

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@
 
 ## Installation
 
-We require the in-development version of `pak` with its bundled library, at least for now.  Our installation instructions are a bit unusual as a result:
 
 ```r
-install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-pak::pkg_install("mrc-ide/pkgbuilder")
+remotes::install_github("mrc-ide/pkgbuilder")
 ```
 
 ## Usage

--- a/scripts/update_web.sh
+++ b/scripts/update_web.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+DOCS_DIR=docs
+VERSION=$(git rev-parse --short HEAD)
+REMOTE_URL=$(git config --get remote.origin.url)
+
+mkdir -p ${DOCS_DIR}
+rm -rf ${DOCS_DIR}/.git
+git init ${DOCS_DIR}
+git -C ${DOCS_DIR} checkout --orphan gh-pages
+git -C ${DOCS_DIR} add .
+git -C ${DOCS_DIR} commit --no-verify -m "Update docs for version ${VERSION}"
+git -C ${DOCS_DIR} remote add origin -m "gh-pages" ${REMOTE_URL}
+git -C ${DOCS_DIR} push --force -u origin gh-pages

--- a/tests/testthat/test-build.R
+++ b/tests/testthat/test-build.R
@@ -2,53 +2,53 @@ context("build")
 
 test_that("pb_install_dependencies does not install NULL extra deps", {
   skip_if_not_installed("mockery")
-  mock_pkg_install <- mockery::mock()
-  mock_local_install_dev_deps <- mockery::mock()
+  mock_install_extra <- mockery::mock()
+  mock_install_deps <- mockery::mock()
 
   path <- tempfile()
   extra <- NULL
   workdir <- tempfile()
 
   res <- with_mock(
-    "pak::pkg_install" = mock_pkg_install,
-    "pak::local_install_dev_deps" = mock_local_install_dev_deps,
+    "pkgbuilder::install_extra" = mock_install_extra,
+    "pkgbuilder::install_deps" = mock_install_deps,
     pb_install_dependencies(path, extra, workdir))
 
-  mockery::expect_called(mock_pkg_install, 0)
+  mockery::expect_called(mock_install_extra, 0)
 
-  mockery::expect_called(mock_local_install_dev_deps, 1)
-  args <- mockery::mock_args(mock_local_install_dev_deps)[[1]]
+  mockery::expect_called(mock_install_deps, 1)
+  args <- mockery::mock_args(mock_install_deps)[[1]]
   lib <- args[[2]]
   expect_true(same_path(dirname(lib), workdir))
   expect_match(basename(lib), "^pb_lib_")
-  expect_equal(args, list(path, lib, ask = FALSE))
+  expect_equal(args, list(path, lib))
 })
 
 
 test_that("pb_install_dependencies installs extra deps", {
   skip_if_not_installed("mockery")
-  mock_pkg_install <- mockery::mock()
-  mock_local_install_dev_deps <- mockery::mock()
+  mock_install_extra <- mockery::mock()
+  mock_install_deps <- mockery::mock()
 
   path <- tempfile()
   extra <- c("a/b", "c/d")
   workdir <- tempfile()
 
   res <- with_mock(
-    "pak::pkg_install" = mock_pkg_install,
-    "pak::local_install_dev_deps" = mock_local_install_dev_deps,
+    "pkgbuilder:::install_extra" = mock_install_extra,
+    "pkgbuilder:::install_deps" = mock_install_deps,
     pb_install_dependencies(path, extra, workdir))
 
-  mockery::expect_called(mock_pkg_install, 1)
-  args <- mockery::mock_args(mock_pkg_install)[[1]]
+  mockery::expect_called(mock_install_extra, 1)
+  args <- mockery::mock_args(mock_install_extra)[[1]]
   lib <- args[[2]]
   expect_true(same_path(dirname(lib), workdir))
   expect_match(basename(lib), "^pb_lib_")
-  expect_equal(args, list(extra, lib, ask = FALSE))
+  expect_equal(args, list(extra, lib))
 
-  mockery::expect_called(mock_local_install_dev_deps, 1)
-  args <- mockery::mock_args(mock_local_install_dev_deps)[[1]]
-  expect_equal(args, list(path, lib, ask = FALSE))
+  mockery::expect_called(mock_install_deps, 1)
+  args <- mockery::mock_args(mock_install_deps)[[1]]
+  expect_equal(args, list(path, lib))
 })
 
 

--- a/tests/testthat/test-z-build.R
+++ b/tests/testthat/test-z-build.R
@@ -24,7 +24,7 @@ test_that("build a package with compiled code", {
   dir_create(lib)
   install.packages(res, lib, repos = NULL)
 
-  expect_true(all(c("R6", "ring") %in% dir(lib)))
+  expect_true("ring" %in% dir(lib))
 })
 
 

--- a/tests/testthat/test-z-build.R
+++ b/tests/testthat/test-z-build.R
@@ -8,11 +8,6 @@ test_that("build a package", {
 
   lib <- tempfile()
   dir_create(lib)
-  ## Installing this does not work with pak as it gets confused about
-  ## it not being a source package.
-  ## > pak::local_install(res, lib)
-  ## > pak::pkg_install(paste0("local::", res), lib)
-  ## However, a direct install does work
   install.packages(res, lib, repos = NULL)
 
   expect_true("defer" %in% dir(lib))
@@ -27,7 +22,7 @@ test_that("build a package with compiled code", {
 
   lib <- tempfile()
   dir_create(lib)
-  pak::local_install(res, lib)
+  install.packages(res, lib, repos = NULL)
 
   expect_true(all(c("R6", "ring") %in% dir(lib)))
 })
@@ -46,7 +41,7 @@ test_that("build a package with extra dependencies", {
 
   lib <- tempfile()
   dir_create(lib)
-  pak::local_install(res, lib)
+  install.packages(res, lib, repos = NULL)
 
   expect_true("dde" %in% dir(lib))
 })


### PR DESCRIPTION
Ages ago, Gabor told me pak was just a wrapper over pkgdepends with a private library, and given we do not persist the library, this works well for us.